### PR TITLE
fix: Buffer deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = function (opts) {
     if (opts.objectMode && !opts.toBufferStream)
       jsonl.push(value)
     else if (opts.toBufferStream)
-      jsonl.push(new Buffer(JSON.stringify(value) + (opts.separator || "\n")))
+      jsonl.push(Buffer.from(JSON.stringify(value) + (opts.separator || "\n")))
     else
       jsonl.push(JSON.stringify(value) + (opts.separator || "\n"))
   }


### PR DESCRIPTION
I'm updating how you create a new Buffer in order to make the warning to go away.

![deprecation-warning](https://github.com/stephenplusplus/jsonl/assets/32243459/521e71f7-f58b-4030-a38e-d30203d44a8a)
